### PR TITLE
Should solve incorrect logic, and adds default for no escape.

### DIFF
--- a/MvpUtility/Config.cs
+++ b/MvpUtility/Config.cs
@@ -99,6 +99,13 @@
             /// </summary>
             [Description("Whether to show who killed the least humans as human, only takes three params")]
             public Dictionary<bool, string> ShowLeastKillsHuman { get; set; } = new Dictionary<bool, string> { { false, string.Empty } };
+
+
+            /// <summary>
+            /// Gets or sets whether to show what to default to.
+            /// </summary>
+            [Description("Default output if no one escapes (No params)")]
+            public Dictionary<bool, string> NoEscapeString { get; set; } = new Dictionary<bool, string> { { false, string.Empty } };
         }
     }
 }


### PR DESCRIPTION
I forgot that the killer dictionary is what I needed to get the total count from, not the subsequent types of killed entitles. 